### PR TITLE
UTC everywhere in AdminUI

### DIFF
--- a/www/js/components/pages/images/list.jsx
+++ b/www/js/components/pages/images/list.jsx
@@ -16,7 +16,7 @@ var ImagesList = React.createClass({
     renderItem: function (i) {
         var img = i.toJSON();
         var href = '/images/' + img.uuid;
-        var publishDate = moment(img.published_at).format('MM/DD/YYYY');
+        var publishDate = moment(img.published_at).utc().format('MM/DD/YYYY');
         var os = img.type === 'zvol' ? ('KVM, ' + img.os) : img.os;
 
         return <tr key={img.uuid}>

--- a/www/js/models/job.js
+++ b/www/js/models/job.js
@@ -69,8 +69,8 @@ var Job = Model.extend({
     duration: function() {
         var d = _.map(this.get('chain_results'), function(task) {
             var t = _.clone(task);
-            t.started_at = moment(task.started_at).format('YYYY-MM-DD HH:mm:ss');
-            t.finished_at = moment(task.finished_at).format('YYYY-MM-DD HH:mm:ss');
+            t.started_at = moment(task.started_at).utc().format('YYYY-MM-DD HH:mm:ss');
+            t.finished_at = moment(task.finished_at).utc().format('YYYY-MM-DD HH:mm:ss');
             t.duration = moment(task.finished_at).diff(moment(task.started_at), 'seconds', true);
             return t;
         });

--- a/www/js/views/job.js
+++ b/www/js/views/job.js
@@ -47,8 +47,8 @@ var JobDetailsComponent = React.createClass({
         job.finished = this.state.job.finished();
         job.chain_results = _.map(job.chain_results, function(task) {
             var t = _.clone(task);
-            t.started_at = moment(task.started_at).format('YYYY-MM-DD HH:mm:ss');
-            t.finished_at = moment(task.finished_at).format('YYYY-MM-DD HH:mm:ss');
+            t.started_at = moment(task.started_at).utc().format('YYYY-MM-DD HH:mm:ss');
+            t.finished_at = moment(task.finished_at).utc().format('YYYY-MM-DD HH:mm:ss');
             t.duration = moment(task.finished_at).diff(moment(task.started_at), 'seconds', true) + 's';
             return t;
         });


### PR DESCRIPTION
This PR fixes an incorrect datetime shown on /jobs/:uuid, where under the "Task Summary" steps the datetime was being displayed in my local timezone but not labeled as such. This leads me to incorrectly assume it to be UTC, as everything else is UTC in AdminUI. 

This also explicitly sets the datetime to UTC on the image list page. This isn't major as the datetime was displayed as MM/DD/YYYY, but I've changed it nevertheless. 