### PR TITLE
Correction to Image Listings (on Images Tab and Provisioning Typeahead)

### DIFF
--- a/tools/devrun.sh
+++ b/tools/devrun.sh
@@ -10,6 +10,7 @@
 #
 
 port=$(cat `pwd`/etc/config.json | json sslport)
+export PATH="$(pwd)/build/node/bin:$PATH"
 
 echo "Will rebundle when needed";
 WATCH=true tools/build-js | ./node_modules/bunyan/bin/bunyan &

--- a/www/js/components/pages/images/index.jsx
+++ b/www/js/components/pages/images/index.jsx
@@ -132,7 +132,7 @@ var ImagesView = React.createClass({
                     </div>
                 </div>
             </div>
-            { this.state.loaded && <ImagesList images={this.state.images} /> }
+            { this.state.loaded && <ImagesList images={this.state.images.fullCollection} /> }
             { (this.state.hasMore) ? <button onClick={this._loadMore} className="btn btn-block btn-info load-more">Load More</button> : ''}
         </div>;
 

--- a/www/js/views/typeahead-image.js
+++ b/www/js/views/typeahead-image.js
@@ -68,7 +68,7 @@ var ImageTypeaheadView = Backbone.Marionette.View.extend({
                     }
                 },
                 filter: function (images) {
-                    var datums = images.map(function (img) {
+                    var datums = images.fullCollection.map(function (img) {
                         var model = new Image(img);
                         var image = model.toJSON();
                         var tokens = [image.uuid, image.name];


### PR DESCRIPTION
The exists an issue whereby lists of images are being mistakenly truncated. The backing data structure for image lists is a Backbone PageableCollection, which is designed to carry a large set of entries but only present a subset of them as one would expect in pagination. 

Image Typeahead Problem:
The Image Typeahead present on the VM provisioning page creates an ImageCollection that requests *all* images. Since the default page size for the collection is 10, the subsequent call to .map on the collection only exposes the first 10 entries. Request logging shows that all images are actually pulled down from /api/images. By using .fullCollection.map, the typeahead gets access to all the entries and can setup its datasource correctly.

Image List Problem:
Similarly an image collection is created to support the list on this page, but there is a different issue. This collection only fetches 25 entries (by adding limitTo to the GET parameters) but the same issue of page size is encountered. This is demonstrated by only 10 entries being shown despite 25 being fetched. Additionally, the 'Load More' button has no effect. Despite an additional 25 entires being properly pulled from the server, they are not displayed because there is no mechanism in place to change the 'currentPage' attribute of the pageableCollection (both code and UI wise). A simple workaround is to also use the .fullCollection property in this case. This causes the display of all 25 initial entries and subsequent uses of the 'Load More' button are also successful as the new entries are simply appended to the collection.

devrun.sh fix:
An additional line to alter the PATH variable to ensure that the separate install of node that 'make dev' installs is used. Failure to do so and should the system have a newer node, various errors will be encountered during start-up.