### PR TITLE
ADMINUI-2305 VM page cannot be displayed for Manta zones

### DIFF
--- a/www/js/components/pages/vm/index.jsx
+++ b/www/js/components/pages/vm/index.jsx
@@ -257,16 +257,20 @@ var VMPage = React.createClass({
 
                             <tr>
                                 <th>Package</th>
-                                <td>
-                                    <a className="package" href={'/packages/' + vm.billing_id} onClick={function (e) {
-                                        e.preventDefault();
-                                        adminui.router.showPackage(vm.billing_id);
-                                    }}>
-                                        <span className="package-name">{pkg.name}</span> &nbsp;
-                                        <span className="package-version">{pkg.version}</span>
-                                    </a>
-                                    <span className="billing-id selectable">{vm.billing_id}</span>
-                                </td>
+                                {pkg ?
+                                    <td>
+                                        <a className="package" href={'/packages/' + vm.billing_id} onClick={function (e) {
+                                            e.preventDefault();
+                                            adminui.router.showPackage(vm.billing_id);
+                                        }}>
+                                            <span className="package-name">{pkg.name}</span> &nbsp;
+                                            <span className="package-version">{pkg.version}</span>
+                                        </a>
+                                        <span className="billing-id selectable">{vm.billing_id}</span>
+                                    </td>
+                                    :
+                                    <td><span className="package-name error">Error retrieving Package information</span></td>
+                                }
                             </tr>
 
                             {vm.datasets.length ?


### PR DESCRIPTION
The VM details page cannot be displayed for Manta zones at the moment, as they have no valid package (`billing_id` is all zeros). The code in `components/pages/vm/index.jsx` is assuming that `pkg` will always be found and valid and dereferences it at line ~265.

I've copied the ternary here from the recently added one for the VM image just above it.