### PR TITLE
TRITON-???? Allow changing whether firewalls are enabled by default for new VMs through SAPI setting

### DIFF
--- a/lib/vms.js
+++ b/lib/vms.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2024 Spearhead Systems SRL.
  */
 /* eslint-disable max-len */
 
@@ -93,6 +94,13 @@ var getVmsParams = function (params) {
 function create(req, res, next) {
     req.body.creator_uuid = req.session.data.user;
     req.body.origin = 'adminui';
+
+    // If this flag is set in etc/config.json, we want to enable the firewall
+    // for a new VM whenever we are creating one.
+    var enable_fw = req.config.datacenters[req.dc].vmapi.enableDefaultFirewall;
+    if (enable_fw) {
+        req.body.firewall_enabled = true;
+    }
 
     req.log.info(req.body, 'VMAPI Create Request');
     req.sdc[req.dc].vmapi.createVm(

--- a/sapi_manifests/adminui/template
+++ b/sapi_manifests/adminui/template
@@ -46,6 +46,9 @@
 				"url": "http://{{{AMON_SERVICE}}}"
 			},
 			"vmapi": {
+				{{#adminui_enable_default_firewall}}
+				"enableDefaultFirewall": true,
+				{{/adminui_enable_default_firewall}}
 				"url": "http://{{{VMAPI_SERVICE}}}"
 			},
 			"cnapi": {


### PR DESCRIPTION
Currently, adminui creates all VMs with firewall disabled. Indeed, (IIRC) there are no widgets for enabling a firewall when provisioning though adminui.

In any case, in our use-case we _always_ want the firewall enabled. This patch adds a SAPI setting; when this is enabled, it switches the default. No danger of forgetting then!

Note that this patch does not preclude later adding support for enabling firewalls when provisioning to adminui, since a different default is useful there too.

This has been tested before/after, and is already being used in prod (admittedly only a couple weeks).