### PR TITLE
TRITON-2515: NIC tag example should be working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "author": "MNX Cloud (mnx.io)",
+  "author": "Edgecast Cloud (edgecast.io)",
   "name": "adminui",
   "description": "Triton Operations Portal",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/www/js/components/pages/networking/fabric-vlan-form.jsx
+++ b/www/js/components/pages/networking/fabric-vlan-form.jsx
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2015, Joyent, Inc.
+ * Copyright 2025 Edgecast Cloud LLC
  */
 
 'use strict';

--- a/www/js/components/pages/networking/fabric-vlan-form.jsx
+++ b/www/js/components/pages/networking/fabric-vlan-form.jsx
@@ -6,7 +6,7 @@
 
 /*
  * Copyright (c) 2015, Joyent, Inc.
- * Copyright 2025 Edgecast Cloud LLC
+ * Copyright 2025 Edgecast Cloud LLC.
  */
 
 'use strict';

--- a/www/js/components/pages/networking/fabric-vlan-form.jsx
+++ b/www/js/components/pages/networking/fabric-vlan-form.jsx
@@ -131,7 +131,7 @@ var FabricVlanForm = React.createClass({
                         <div className="form-group">
                             <label className="control-label col-sm-4">Name</label>
                             <div className="controls col-sm-7">
-                                <input placeholder="name of Fabric VLAN (eg: acme-admin)" onChange={this._onChangeName} type="text" value={this.state.name} className="form-control" name="name" />
+                                <input placeholder="name of Fabric VLAN (eg: acme_admin)" onChange={this._onChangeName} type="text" value={this.state.name} className="form-control" name="name" />
                             </div>
                         </div>
                         <div className="form-group">

--- a/www/js/views/nictag-form.jsx
+++ b/www/js/views/nictag-form.jsx
@@ -6,7 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
- * Copyright 2025 Edgecast Cloud LLC
+ * Copyright 2025 Edgecast Cloud LLC.
  */
 
 var React = require('react');

--- a/www/js/views/nictag-form.jsx
+++ b/www/js/views/nictag-form.jsx
@@ -32,7 +32,7 @@ var NicTagForm = React.createClass({
                     <div className="form-group">
                         <label className="control-label col-sm-5">NIC Tag Name</label>
                         <div className="col-sm-5">
-                            <input placeholder="name of NIC Tag (eg: acme-admin)" onChange={this._onChangeName} type="text" value={this.state.name} className="form-control" />
+                            <input placeholder="name of NIC Tag (eg: acme_admin)" onChange={this._onChangeName} type="text" value={this.state.name} className="form-control" />
                         </div>
                     </div>
                     <div className="form-group">

--- a/www/js/views/nictag-form.jsx
+++ b/www/js/views/nictag-form.jsx
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2025 Edgecast Cloud LLC
  */
 
 var React = require('react');


### PR DESCRIPTION
When an operator wants to add a new NIC tag, they currently see a non-working example NIC tag: `acme-admin`. A working example would be `acme_admin`.